### PR TITLE
[IMP] (Closes #33) Proceduralize GL abstractions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(solassitude
 			   src/gl_vertex_array.cpp
 			   src/gl_buffer.cpp
 			   src/glew_abstract.cpp
-			   src/glfw_abstract.cpp)
+			   src/glfw_abstract.cpp
+			   src/gl_reference.cpp)
 
 set_target_properties(
 	solassitude PROPERTIES

--- a/include/solassitude/gl_abstract.h
+++ b/include/solassitude/gl_abstract.h
@@ -48,6 +48,12 @@ namespace solassitude {
             return static_cast<int>(a & b) != 0;
         }
         
+        
+        
+        
+        
+        
         void clear(buffer_bits bitmask);
+        
     }
 }

--- a/include/solassitude/gl_buffer.h
+++ b/include/solassitude/gl_buffer.h
@@ -5,9 +5,6 @@
 
 namespace solassitude {
 	namespace gl {
-		class buffers;
-		class buffer;
-		
 		enum class buffer_target {
 			array,
 			atomic_counter,
@@ -24,24 +21,6 @@ namespace solassitude {
 			transform_feedback,
 			uniform,
 			none
-		};
-		
-		class buffer_impl : public object {
-		public:
-			explicit buffer_impl(buffer_target target, unsigned int id) : object{ id }, m_target{ target } { }
-			~buffer_impl() { }
-			
-			buffer_impl &bind(void);
-			
-			constexpr buffer_target target(void) const noexcept {
-				return m_target;
-			}
-			
-			void target(buffer_target new_target) noexcept {
-				m_target = new_target;
-			}
-		private:
-			buffer_target m_target;
 		};
 	}
 }

--- a/include/solassitude/gl_reference.h
+++ b/include/solassitude/gl_reference.h
@@ -5,27 +5,23 @@
 
 namespace solassitude {
 	namespace gl {
-		template <class derived_t> class reference {
+		template <class derived_t> class reference : public object {
 		public:
-			explicit reference(unsigned int _id) : m_id{ _id } { }
+			explicit reference(unsigned int _id) : object{ _id } { }
 			
 			~reference() { static_cast<derived_t &>(*this).on_destruct(); }
 			
-			constexpr unsigned int id(void) const noexcept { return m_id; }
-			
-			constexpr void id(unsigned int id) noexcept { m_id = id; }
-			
-			explicit reference(const reference<derived_t> &copy) : m_id{ copy.m_id } { 
-				static_cast<derived_t *>(this)->on_copy(static_cast<const derived_t &>(std::forward(copy)), false);
+			explicit reference(const reference<derived_t> &copy) : object{ copy } { 
+				static_cast<derived_t &>(*this).on_copy(static_cast<const derived_t &>(std::forward(copy)), false);
 			}
 			
-			explicit reference(reference<derived_t> &&move) : m_id{ std::move(move.m_id) } {
-				static_cast<derived_t *>(this)->on_move(static_cast<derived_t &&>(std::forward(move)), false);
+			explicit reference(reference<derived_t> &&move) : object{ std::move(move) } {
+				static_cast<derived_t &>(*this).on_move(static_cast<derived_t &&>(std::forward(move)), false);
 			}
 			
 			reference<derived_t> &operator =(const reference<derived_t> &copy) {
 				if (&copy != this) {
-					m_id = copy.m_id;
+					this->operator=(std::forward(copy)); // copy assign object id
 					static_cast<derived_t &>(*this).on_copy(static_cast<const derived_t &>(std::forward(copy)), true);
 				}
 				return *this;
@@ -33,8 +29,8 @@ namespace solassitude {
 			
 			reference<derived_t> &operator =(reference<derived_t> &&move) {
 				if (&move != this) {
-					m_id = std::move(move.m_id);
-					static_cast<derived_t &>(*this)->on_move(static_cast<derived_t &&>(std::forward(move)), true);
+					this->operator=(std::forward(move)); // move assign object id
+					static_cast<derived_t &>(*this).on_move(static_cast<derived_t &&>(std::forward(move)), true);
 				}
 				return *this;
 			}
@@ -47,9 +43,6 @@ namespace solassitude {
 			void on_copy(const derived_t &copy, bool is_assign) { }
 			void on_move(derived_t &&move, bool is_assign) { }
 			void on_activate(void) { }
-			
-		private:
-			unsigned int m_id;
 		};
 	}
 }

--- a/include/solassitude/gl_reference.h
+++ b/include/solassitude/gl_reference.h
@@ -8,15 +8,21 @@ namespace solassitude {
 		template <class derived_t> class reference {
 		public:
 			explicit reference(unsigned int _id) : m_id{ _id } { }
+			
 			~reference() { static_cast<derived_t &>(*this).on_destruct(); }
+			
 			constexpr unsigned int id(void) const noexcept { return m_id; }
+			
 			constexpr void id(unsigned int id) noexcept { m_id = id; }
+			
 			explicit reference(const reference<derived_t> &copy) : m_id{ copy.m_id } { 
 				static_cast<derived_t *>(this)->on_copy(static_cast<const derived_t &>(std::forward(copy)), false);
 			}
+			
 			explicit reference(reference<derived_t> &&move) : m_id{ std::move(move.m_id) } {
 				static_cast<derived_t *>(this)->on_move(static_cast<derived_t &&>(std::forward(move)), false);
 			}
+			
 			reference<derived_t> &operator =(const reference<derived_t> &copy) {
 				if (&copy != this) {
 					m_id = copy.m_id;
@@ -24,6 +30,7 @@ namespace solassitude {
 				}
 				return *this;
 			}
+			
 			reference<derived_t> &operator =(reference<derived_t> &&move) {
 				if (&move != this) {
 					m_id = std::move(move.m_id);
@@ -31,6 +38,7 @@ namespace solassitude {
 				}
 				return *this;
 			}
+			
 			void activate(void) { static_cast<derived_t &>(*this).on_activate(); }
 			
 		protected:

--- a/include/solassitude/gl_reference.h
+++ b/include/solassitude/gl_reference.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "gl_abstract.h"
+#include <utility>
+
+namespace solassitude {
+	namespace gl {
+		template <class derived_t> class reference {
+		public:
+			explicit reference(unsigned int _id) : m_id{ _id } { }
+			~reference() { static_cast<derived_t &>(*this).on_destruct(); }
+			constexpr unsigned int id(void) const noexcept { return m_id; }
+			constexpr void id(unsigned int id) noexcept { m_id = id; }
+			explicit reference(const reference<derived_t> &copy) : m_id{ copy.m_id } { 
+				static_cast<derived_t *>(this)->on_copy(static_cast<const derived_t &>(std::forward(copy)), false);
+			}
+			explicit reference(reference<derived_t> &&move) : m_id{ std::move(move.m_id) } {
+				static_cast<derived_t *>(this)->on_move(static_cast<derived_t &&>(std::forward(move)), false);
+			}
+			reference<derived_t> &operator =(const reference<derived_t> &copy) {
+				if (&copy != this) {
+					m_id = copy.m_id;
+					static_cast<derived_t &>(*this).on_copy(static_cast<const derived_t &>(std::forward(copy)), true);
+				}
+				return *this;
+			}
+			reference<derived_t> &operator =(reference<derived_t> &&move) {
+				if (&move != this) {
+					m_id = std::move(move.m_id);
+					static_cast<derived_t &>(*this)->on_move(static_cast<derived_t &&>(std::forward(move)), true);
+				}
+				return *this;
+			}
+			void activate(void) { static_cast<derived_t &>(*this).on_activate(); }
+			
+		protected:
+		
+			void on_destruct(void) { }
+			void on_copy(const derived_t &copy, bool is_assign) { }
+			void on_move(derived_t &&move, bool is_assign) { }
+			void on_activate(void) { }
+			
+		private:
+			unsigned int m_id;
+		};
+	}
+}

--- a/include/solassitude/gl_vertex_array.h
+++ b/include/solassitude/gl_vertex_array.h
@@ -1,49 +1,31 @@
 #pragma once
 
 #include "gl_abstract.h"
-#include <vector>
+#include "gl_reference.h"
+//#include <vector>
+#include <utility> // std::forward
 
 namespace solassitude {
 	namespace gl {
-		class vertex_arrays;
 		class vertex_array;
-		/*
-		class vertex_array {
-		private:
-			friend class vertex_arrays;
-			explicit vertex_array(unsigned int vao) : m_vao{ vao } { }
-			
-		public:
-			vertex_array &bind(void);
-			
-		private:
-			unsigned int m_vao;	
-		};*/
 		
-		class vertex_array : public object {
-		private:
-			friend class vertex_arrays;
-			explicit vertex_array(unsigned int vao) : object{ vao } { }
+		class vertex_array : 
+			public reference<vertex_array> {
+				
 		public:
-			vertex_array &bind(void);
-			~vertex_array() { }
-		};
-		
-		class vertex_arrays {
-		public:
-			explicit vertex_arrays(int n = 1);
-			~vertex_arrays();
+			explicit vertex_array(unsigned int id) : reference{ id } { }
+			explicit vertex_array(); // generate one with a new id.
+			~vertex_array() { } // destructor needs to be defined, compiler will implicitly call reference::~reference()
+			explicit vertex_array(const vertex_array &copy) : reference{ copy } { } // c++ does not inherit constructors
+			explicit vertex_array(vertex_array &&move) : reference{ std::move(move) } { }
 			
-			vertex_array operator[](int i) noexcept {
-				return vertex_array{ m_vaos.at(i) }.bind();
-			}
+		protected:
+			// The base class will call on_* methods (CRTP/NVI pattern).
 			
-			unsigned int size() const noexcept {
-				return m_vaos.size();
-			}
-			
-		private:
-			std::vector<unsigned int> m_vaos;
+			void on_destruct(void); // called by the base destructor
+			void on_activate(void); // called by base activate() method
+			void on_copy(const vertex_array &copy, bool is_assign); // called by base copy c'tor and assignment operator
+			void on_move(vertex_array &&move, bool is_assign); // called by base move c'tor and assignment operator
 		};
 	}
 }

--- a/include/solassitude/gl_vertex_attributes.h
+++ b/include/solassitude/gl_vertex_attributes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace solassitude {
+	namespace gl {
+		template <typename data_type_t> struct attribute_traits {
+			
+		};
+	}
+}

--- a/src/gl_buffer.cpp
+++ b/src/gl_buffer.cpp
@@ -30,17 +30,3 @@ static constexpr GLenum _solassitude_to_gl(solassitude::gl::buffer_target target
 	}
 }
 
-/*
-solassitude::gl::buffer &solassitude::gl::buffer::bind(solassitude::gl::buffer_target target) {
-	m_target = target;
-	::glBindBuffer(_solassitude_to_gl(m_target), m_id);
-	__GL_CHECK_ERROR
-	return *this;
-}
-*/
-
-solassitude::gl::buffer_impl &solassitude::gl::buffer_impl::bind(void) {
-	::glBindBuffer(_solassitude_to_gl(target()), id());
-	__GL_CHECK_ERROR
-	return *this;
-}

--- a/src/gl_reference.cpp
+++ b/src/gl_reference.cpp
@@ -1,0 +1,1 @@
+#include <solassitude/gl_reference.h>

--- a/src/gl_vertex_array.cpp
+++ b/src/gl_vertex_array.cpp
@@ -10,6 +10,9 @@
 
 #define __GL_CHECK_ERROR GLenum err{ ::glGetError() }; if (err != GL_NO_ERROR) { throw solassitude::gl::error{ err }; }
 
+#include <stdexcept> // std::logic_error
+
+/*
 solassitude::gl::vertex_arrays::vertex_arrays(int n) {
 	m_vaos.resize(n);
 	glGenVertexArrays(n, m_vaos.data());
@@ -30,3 +33,45 @@ solassitude::gl::vertex_array &solassitude::gl::vertex_array::bind(void) {
 	
 	return *this;
 }
+*/
+
+static inline GLuint _solassitude_new_vertex_array() {
+	GLuint object_id;
+	::glGenVertexArrays(1, &object_id);
+	__GL_CHECK_ERROR
+	return object_id;
+}
+
+solassitude::gl::vertex_array::vertex_array() : vertex_array{ _solassitude_new_vertex_array() } 
+{
+}
+
+void solassitude::gl::vertex_array::on_destruct(void) {
+	// Called by d'tor - no throwing exceptions, otherwise std::terminate is called
+	// This method won't be called if c'tor threw exception, as that means the object
+	// is NOT constructed, no d'tor will be called. Object ID is guaranteed to be valid.
+	GLuint object_id{ id() }; // don't use pointer to prvalue as an input argument for pointer parameter!
+	::glDeleteVertexArrays(1, &object_id);
+	__GL_CHECK_ERROR
+}
+
+void solassitude::gl::vertex_array::on_activate(void) {
+	::glBindVertexArray(id());
+	__GL_CHECK_ERROR
+}
+
+void solassitude::gl::vertex_array::on_copy(const solassitude::gl::vertex_array &copy, bool is_assign) {
+	// TODO: How to clone a VAO? Help wanted.
+	throw std::logic_error{ "VAO cloning not yet implemented" };
+}
+
+void solassitude::gl::vertex_array::on_move(solassitude::gl::vertex_array &&move, bool is_assign) {
+	// Make use the VAO is detached
+	::glBindVertexArray(0);
+	
+	if (is_assign)
+		this->on_destruct(); // Move assignment, destroy current one
+		
+	// ID move is handled by the base class, and we have no more fields to copy.
+}
+

--- a/src/gl_vertex_array.cpp
+++ b/src/gl_vertex_array.cpp
@@ -12,29 +12,6 @@
 
 #include <stdexcept> // std::logic_error
 
-/*
-solassitude::gl::vertex_arrays::vertex_arrays(int n) {
-	m_vaos.resize(n);
-	glGenVertexArrays(n, m_vaos.data());
-	
-	__GL_CHECK_ERROR
-}
-
-solassitude::gl::vertex_arrays::~vertex_arrays() {
-	glDeleteVertexArrays(m_vaos.size(), m_vaos.data());
-	
-	// No need to check for error, n will be always greater than 0.
-}
-
-solassitude::gl::vertex_array &solassitude::gl::vertex_array::bind(void) {
-	glBindVertexArray(id());
-	
-	__GL_CHECK_ERROR
-	
-	return *this;
-}
-*/
-
 static inline GLuint _solassitude_new_vertex_array() {
 	GLuint object_id;
 	::glGenVertexArrays(1, &object_id);

--- a/src/solassitude.cpp
+++ b/src/solassitude.cpp
@@ -38,7 +38,9 @@ int main(int argc, char const *argv[])
     
     window.input_mode(solassitude::glfw::input_modes::sticky_keys, true);
     
-    solassitude::gl::vertex_arrays vaos{ 1 };
+    solassitude::gl::vertex_array vao;
+    vao.activate();
+    
     
     do {
         // clear screen


### PR DESCRIPTION
- Introduced gl::object, which is a very small class consisting of only object ID.
- Introduced gl::reference, implementing copy, move, bind and delete functions common between GL objects.
- Rewrote gl::vertex_array in terms of gl::reference (proceduralized)
- Removed gl::buffer and gl::buffer_impl, we'll rewrite it in terms of gl::reference anyways.